### PR TITLE
Fixes #19. Add highligh.js implementation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "editor.defaultFormatter": "esbenp.prettier-vscode",
-  "editor.formatOnSave": true
+  "editor.formatOnSave": true,
+  "cSpell.words": ["hljs"]
 }

--- a/dodo-SSG.js
+++ b/dodo-SSG.js
@@ -4,7 +4,17 @@ const fs = require("fs");
 const path = require("path");
 const yargs = require("yargs");
 const { version } = require("./package.json");
-const md = require("markdown-it")();
+const hljs = require("highlight.js");
+const md = require("markdown-it")({
+  highlight: (str, lang) => {
+    if (lang && hljs.getLanguage(lang)) {
+      try {
+        return hljs.highlight(str, { language: lang }).value;
+      } catch (__) {}
+    }
+    return "";
+  },
+});
 
 const argv = yargs
   .usage("Usage: $0 [options]")
@@ -32,6 +42,7 @@ const writeHTMLFile = (title, body, file, fileType, stylesheet) => {
       <title>${title}</title>
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <link rel="stylesheet" href="${stylesheet}">
+      <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/highlightjs@9.16.2/styles/github.css">
     </head>
     <body>
       <h1>${title}</h1>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "highlight.js": "^11.3.1",
         "markdown-it": "^12.2.0",
         "yargs": "^17.1.1"
       },
@@ -99,6 +100,14 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.3.1.tgz",
+      "integrity": "sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw==",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/is-fullwidth-code-point": {
@@ -297,6 +306,11 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "highlight.js": {
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.3.1.tgz",
+      "integrity": "sha512-PUhCRnPjLtiLHZAQ5A/Dt5F8cWZeMyj9KRsACsWT+OD6OP0x6dp5OmT5jdx0JgEyPxPZZIPQpRN2TciUT7occw=="
     },
     "is-fullwidth-code-point": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "author": "Francesco Menghi",
   "license": "MIT",
   "dependencies": {
+    "highlight.js": "^11.3.1",
     "markdown-it": "^12.2.0",
     "yargs": "^17.1.1"
   },


### PR DESCRIPTION
This PR adds initial support for syntax highlighting using [highlight.js](https://highlightjs.org). This uses the [github](https://cdn.jsdelivr.net/npm/highlightjs@9.16.2/styles/github.css) theme.